### PR TITLE
Wrong contract hinted for job var (Jobs instead of Job)

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -7,7 +7,7 @@ trait InteractsWithQueue {
 	/**
 	 * The underlying queue job instance.
 	 *
-	 * @var \Illuminate\Contracts\Queue\Jobs
+	 * @var \Illuminate\Contracts\Queue\Job
 	 */
 	protected $job;
 


### PR DESCRIPTION
protected $job hints \Illuminate\Contracts\Queue\Jobs instead of \Illuminate\Contracts\Queue\Job